### PR TITLE
In 3D, the default k should by qroot of the number of points in the map

### DIFF
--- a/R/embed.R
+++ b/R/embed.R
@@ -71,7 +71,7 @@ EmbedSOM <- function(fsom=NULL, smooth=NULL, k=NULL, adjust=NULL,
     smooth <- 0
 
   if(is.null(k)) {
-    k <- as.integer(1+sqrt(ncodes))
+    k <- as.integer(1+ncodes^(1/somdim))
   }
 
   if(is.null(adjust)) {


### PR DESCRIPTION
k is the number of SOM points used in the local projection. Ideally, this number should be similar to the number of points in the map in each dimension. I.e., for a map with xdim=ydim=10, k=10 is a good default choice. However, in 3D with xdim=ydim=zdim=10, the k is not set to this value but somewhere above 30.